### PR TITLE
Fixed broken server config merge.

### DIFF
--- a/src/PHPixie/Cache/Drivers/Driver.php
+++ b/src/PHPixie/Cache/Drivers/Driver.php
@@ -91,6 +91,11 @@ abstract class Driver
         return new Item($key, $isHit, $value);
     }
 
+    /**
+     * Check if cleanup is required. And perform cleanup(if required)/
+     *
+     * @return void
+     */
     protected function cleanupCheck()
     {
         if($this->cleanupProbability === null) {

--- a/src/PHPixie/Cache/Drivers/Driver.php
+++ b/src/PHPixie/Cache/Drivers/Driver.php
@@ -28,12 +28,25 @@ abstract class Driver
         $this->configData = $configData;
     }
 
+    /**
+     * Delete item
+     *
+     * @param $key
+     * @return bool
+     */
     public function deleteItem($key)
     {
         $this->deleteItems(array($key));
         return true;
     }
 
+    /**
+     * Save multiple items
+     *
+     * @param array(Item) $items
+     * @param array $expiryTimes corresponding expiry times
+     * @return bool
+     */
     public function saveMultiple($items, $expiryTimes)
     {
         /** @var Item $item */
@@ -44,6 +57,13 @@ abstract class Driver
         return true;
     }
 
+    /**
+     * Build Items
+     *
+     * @param array $keys
+     * @param array $data
+     * @return array
+     */
     protected function buildItems($keys, $data)
     {
         $result = array();
@@ -58,6 +78,14 @@ abstract class Driver
         return $result;
     }
 
+    /**
+     * Build Item object
+     *
+     * @param string $key
+     * @param bool $isHit
+     * @param mixed $value stored value
+     * @return Item
+     */
     public function buildItem($key, $isHit, $value = null)
     {
         return new Item($key, $isHit, $value);
@@ -74,10 +102,13 @@ abstract class Driver
         }
     }
 
+    /**
+     * Default cleanup implementation.
+     *
+     * @return void
+     */
     public function cleanup()
-    {
-
-    }
+    {}
 
     /**
      * @param string $key

--- a/src/PHPixie/Cache/Drivers/Type/Memcached.php
+++ b/src/PHPixie/Cache/Drivers/Type/Memcached.php
@@ -103,6 +103,17 @@ class Memcached extends Driver
     }
 
     /**
+     * Prepare server config, because in app config it could be defined w/o port or weight
+     *
+     * @param array $value
+     * @return array
+     */
+    protected function prepareServerConfig(array $value)
+    {
+        return $value + array(null, 11211, 1);
+    }
+
+    /**
      * Build client
      *
      * @return \Memcached
@@ -112,7 +123,7 @@ class Memcached extends Driver
         $client = new \Memcached();
         $servers = $this->configData->getRequired('servers');
         foreach($servers as $key => $value) {
-            $servers[$key] = $value + array(null, 11211, 1);
+            $servers[$key] = $this->prepareServerConfig($value);
         }
         $client->addServers($servers);
 

--- a/src/PHPixie/Cache/Drivers/Type/Memcached.php
+++ b/src/PHPixie/Cache/Drivers/Type/Memcached.php
@@ -10,7 +10,9 @@ class Memcached extends Driver
     /** @var \Memcached */
     protected $client;
 
-
+    /**
+     * @inheritdoc
+     */
     public function hasItem($key)
     {
         $client = $this->client();
@@ -18,6 +20,9 @@ class Memcached extends Driver
         return $client->getResultCode() == \Memcached::RES_SUCCESS;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getItems(array $keys = array())
     {
         if(empty($keys)) {
@@ -33,12 +38,18 @@ class Memcached extends Driver
         return $this->buildItems($keys, $data);
     }
 
+    /**
+     * @inheritdoc
+     */
     public function deleteItems(array $keys = array())
     {
         $this->client()->deleteMulti($keys);
         return true;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function clear()
     {
         $this->client()->flush();
@@ -65,6 +76,9 @@ class Memcached extends Driver
         return true;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getItem($key)
     {
         $client = $this->client();
@@ -88,6 +102,11 @@ class Memcached extends Driver
         return $this->client;
     }
 
+    /**
+     * Build client
+     *
+     * @return \Memcached
+     */
     protected function buildClient()
     {
         $client = new \Memcached();
@@ -96,6 +115,7 @@ class Memcached extends Driver
             $servers[$key] = array(null, 11211, 1) + $value;
         }
         $client->addServers($servers);
+
         return $client;
     }
 }

--- a/src/PHPixie/Cache/Drivers/Type/Memcached.php
+++ b/src/PHPixie/Cache/Drivers/Type/Memcached.php
@@ -112,7 +112,7 @@ class Memcached extends Driver
         $client = new \Memcached();
         $servers = $this->configData->getRequired('servers');
         foreach($servers as $key => $value) {
-            $servers[$key] = array(null, 11211, 1) + $value;
+            $servers[$key] = $value + array(null, 11211, 1);
         }
         $client->addServers($servers);
 

--- a/src/PHPixie/Cache/Item.php
+++ b/src/PHPixie/Cache/Item.php
@@ -19,31 +19,49 @@ class Item implements CacheItemInterface
         $this->expiresAt = $expiresAt;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function getKey()
     {
         return $this->key;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function get()
     {
         return $this->value;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function isHit()
     {
         return $this->isHit;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function set($value)
     {
         $this->value = $value;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function expiresAt($expiresAt)
     {
         $this->expiresAt = $expiresAt;
     }
 
+    /**
+     * @inheritdoc
+     */
     public function expiresAfter($interval)
     {
         if($interval === null) {
@@ -59,6 +77,11 @@ class Item implements CacheItemInterface
         $this->expiresAt = $expires->add($interval);
     }
 
+    /**
+     * Get exiration datetime
+     *
+     * @return null|\DateTimeInterface
+     */
     public function getExpiresAt()
     {
         return $this->expiresAt;

--- a/tests/PHPixie/Tests/Cache/Driver/MemcachedTest.php
+++ b/tests/PHPixie/Tests/Cache/Driver/MemcachedTest.php
@@ -16,4 +16,48 @@ class MemcachedTest extends DriverTest
             )
         )
     );
+
+    public function testServerConfig()
+    {
+        $driver = $this->cache->storage('default')->driver();
+
+        $params = array(
+            array('127.0.0.1'),
+            array('192.168.1.100'),
+            array('192.168.1.100', 11212),
+            array('192.168.1.100', 11212, 3),
+        );
+        $expected = array(
+            array('127.0.0.1', 11211, 1),
+            array('192.168.1.100', 11211, 1),
+            array('192.168.1.100', 11212, 1),
+            array('192.168.1.100', 11212, 3),
+        );
+
+        foreach (array_keys($params) as $key) {
+            $this->assertEquals(
+                $expected[$key],
+                $this->invokeMethod($driver, 'prepareServerConfig', array($params[$key]))
+            );
+        }
+    }
+
+    /**
+     * Call protected/private method of a class.
+     *
+     * @param object &$object    Instantiated object that we will run method on.
+     * @param string $methodName Method name to call
+     * @param array  $parameters Array of parameters to pass into method.
+     * @link https://jtreminio.com/2013/03/unit-testing-tutorial-part-3-testing-protected-private-methods-coverage-reports-and-crap/
+     *
+     * @return mixed Method return.
+     */
+    public function invokeMethod(&$object, $methodName, array $parameters = array())
+    {
+        $reflection = new \ReflectionClass(get_class($object));
+        $method = $reflection->getMethod($methodName);
+        $method->setAccessible(true);
+
+        return $method->invokeArgs($object, $parameters);
+    }
 }


### PR DESCRIPTION
```
array(null, 11211, 1) + $value
```
is wrong. 
As mentioned at http://php.net/manual/en/language.operators.array.php elements from first array will not be replaced by the elements from second with same keys. And tests proves that.
Probably everybody was working with memc on the same server as php :)

Some docblocks and test for this case added.