### PR TITLE
Added support for persistent connection for Memcached.

### DIFF
--- a/src/PHPixie/Cache/Drivers/Type/Memcached.php
+++ b/src/PHPixie/Cache/Drivers/Type/Memcached.php
@@ -127,8 +127,12 @@ class Memcached extends Driver
             $client = new \Memcached($persistentId);
         }
 
-        // do not add servers if persistence is turned on
-        if (null !== $persistentId && !count($client->getServerList())) {
+        if (null === $persistentId) {
+            $client->setOptions($this->configData->get('options', array()));
+        } else if (empty($client->getServerList())) {
+            // @see https://php.net/manual/en/memcached.construct.php#106865 - options only once
+            // @see https://php.net/manual/en/memcached.construct.php#93536 - do not add twice
+            $client->setOptions($this->configData->get('options', array()));
             $servers = $this->configData->getRequired('servers');
             foreach ($servers as $key => $value) {
                 $servers[$key] = $this->prepareServerConfig($value);

--- a/src/PHPixie/Cache/Drivers/Type/Memcached.php
+++ b/src/PHPixie/Cache/Drivers/Type/Memcached.php
@@ -120,20 +120,14 @@ class Memcached extends Driver
      */
     protected function buildClient()
     {
-        $persistentId = $this->configData->get('persistent_id', null);
-        if (null === $persistentId) {
-            $client = new \Memcached();
-        } else {
-            $client = new \Memcached($persistentId);
-        }
+        $persistentId = $this->configData->get('persistent_id', '');
+        $client = new \Memcached($persistentId);
 
         $serversList = $client->getServerList();
 
-        if (null === $persistentId) {
-            $client->setOptions($this->configData->get('options', array()));
-        } else if (empty($serversList)) {
-            // @see https://php.net/manual/en/memcached.construct.php#106865 - options only once
-            // @see https://php.net/manual/en/memcached.construct.php#93536 - do not add twice
+        // @see https://php.net/manual/en/memcached.construct.php#106865 - options only once
+        // @see https://php.net/manual/en/memcached.construct.php#93536 - do not add twice
+        if ('' === $persistentId || empty($serversList)) {
             $client->setOptions($this->configData->get('options', array()));
             $servers = $this->configData->getRequired('servers');
             foreach ($servers as $key => $value) {

--- a/src/PHPixie/Cache/Drivers/Type/Memcached.php
+++ b/src/PHPixie/Cache/Drivers/Type/Memcached.php
@@ -127,9 +127,11 @@ class Memcached extends Driver
             $client = new \Memcached($persistentId);
         }
 
+        $serversList = $client->getServerList();
+
         if (null === $persistentId) {
             $client->setOptions($this->configData->get('options', array()));
-        } else if (empty($client->getServerList())) {
+        } else if (empty($serversList)) {
             // @see https://php.net/manual/en/memcached.construct.php#106865 - options only once
             // @see https://php.net/manual/en/memcached.construct.php#93536 - do not add twice
             $client->setOptions($this->configData->get('options', array()));

--- a/src/PHPixie/Cache/Drivers/Type/Memcached.php
+++ b/src/PHPixie/Cache/Drivers/Type/Memcached.php
@@ -127,11 +127,14 @@ class Memcached extends Driver
             $client = new \Memcached($persistentId);
         }
 
-        $servers = $this->configData->getRequired('servers');
-        foreach($servers as $key => $value) {
-            $servers[$key] = $this->prepareServerConfig($value);
+        // do not add servers if persistence is turned on
+        if (null !== $persistentId && !count($client->getServerList())) {
+            $servers = $this->configData->getRequired('servers');
+            foreach ($servers as $key => $value) {
+                $servers[$key] = $this->prepareServerConfig($value);
+            }
+            $client->addServers($servers);
         }
-        $client->addServers($servers);
 
         return $client;
     }

--- a/src/PHPixie/Cache/Drivers/Type/Memcached.php
+++ b/src/PHPixie/Cache/Drivers/Type/Memcached.php
@@ -120,7 +120,13 @@ class Memcached extends Driver
      */
     protected function buildClient()
     {
-        $client = new \Memcached();
+        $persistentId = $this->configData->get('persistent_id', null);
+        if (null === $persistentId) {
+            $client = new \Memcached();
+        } else {
+            $client = new \Memcached($persistentId);
+        }
+
         $servers = $this->configData->getRequired('servers');
         foreach($servers as $key => $value) {
             $servers[$key] = $this->prepareServerConfig($value);


### PR DESCRIPTION
Subj. Now it's possible to use persistent connections with `\Memcached`. Just have to declare in `assets/config/cache.php`:
```php
        'persistent_id' => 'my_persistent_id',
        'options'       => [
                \Memcached::OPT_SERIALIZER      => \Memcached::SERIALIZER_IGBINARY,
                \Memcached::OPT_BINARY_PROTOCOL => true,
        ],
```
or 
```php
        'persistent_id' => '%memcached.persistent_id%',
        'options'       => '%memcached.options%',
```
if you want to define it in `assets/parameters.php`.